### PR TITLE
Renamed Drive Vars + Fixed Pairing Includes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -33,8 +33,8 @@ build_src_filter =
     +<Robot/Lights.h>
     +<Pairing/pairing.h>
 	+<Pairing/pairing.cpp>
-    +<Pairing/builtInLED.h>
-    +<Pairing/builtInLED.cpp>	
+    +<Robot/builtInLED.h>
+    +<Robot/builtInLED.cpp>	
     ; -<depairingStation.cpp>
     ; -<Drive/DriveQuick.cpp>
     ; -<Drive/DriveQuick.h>

--- a/src/Drive/Drive.h
+++ b/src/Drive/Drive.h
@@ -94,13 +94,10 @@ protected:
 private:
     MOTORS motorType;
     float BSNscalar;
-
-    float motorPower[NUM_MOTORS];
-    float currentPower[NUM_MOTORS];
+    float requestedMotorPower[NUM_MOTORS];
+    float currentRampPower[NUM_MOTORS];
     float lastRampPower[NUM_MOTORS];
     float turnMotorValues[NUM_MOTORS];
-    // float inputPower[NUM_MOTORS];
-    // float rampedPower[NUM_MOTORS];
     void calcTurningMotorValues(float stickTrn, float prevPwr, int dir);
 public:
 
@@ -114,18 +111,17 @@ public:
     void setServos(uint8_t lpin, uint8_t rpin);
     void setMotorType(MOTORS motorType);
     void setStickPwr(int8_t leftY, int8_t rightX);
-    float getFwdRev();
-    float getTurn();
+    float getForwardPower();
+    float getTurnPower();
     void setBSN(SPEED bsn); //(float powerMultiplier);
     float getBSN();
-    float getMotorPwr(uint8_t mtr);
-    void setMotorPwr(float power, uint8_t mtr);
+    float getReqMotorPwr(uint8_t mtr);
+    void setReqMotorPwr(float power, uint8_t mtr);
     void setLastRampPwr(float power, uint8_t mtr);
     void emergencyStop();
     float ramp(float requestedPower, uint8_t mtr, float accelRate = ACCELERATION_RATE);
     void generateMotionValues();
     void update();
-    void drift();
     void printDebugInfo();
 };
 

--- a/src/Drive/DriveMecanum.cpp
+++ b/src/Drive/DriveMecanum.cpp
@@ -78,10 +78,10 @@ void DriveMecanum::generateMotorValues() {
         https://robotics.stackexchange.com/questions/20088/how-to-drive-mecanum-wheels-robot-code-or-algorithm
     */
 
-    // setMotorPwr(r * x_comp + turnPwr, 0);
-    // setMotorPwr(r * y_comp - turnPwr, 1);
-    // setMotorPwr(r * y_comp + turnPwr, 2);
-    // setMotorPwr(r * x_comp - turnPwr, 3);
+    // setReqMotorPwr(r * x_comp + turnPwr, 0);
+    // setReqMotorPwr(r * y_comp - turnPwr, 1);
+    // setReqMotorPwr(r * y_comp + turnPwr, 2);
+    // setReqMotorPwr(r * x_comp - turnPwr, 3);
 
     
     mmotorpwr[0] = r * x_comp + turnPwr;
@@ -91,19 +91,19 @@ void DriveMecanum::generateMotorValues() {
 
 
 
-    // setMotorPwr(r * x_comp / max + turnPwr, 0);
-    // setMotorPwr(r * y_comp / max - turnPwr, 1);
-    // setMotorPwr(r * y_comp / max + turnPwr, 2);
-    // setMotorPwr(r * x_comp / max - turnPwr, 3);
+    // setReqMotorPwr(r * x_comp / max + turnPwr, 0);
+    // setReqMotorPwr(r * y_comp / max - turnPwr, 1);
+    // setReqMotorPwr(r * y_comp / max + turnPwr, 2);
+    // setReqMotorPwr(r * x_comp / max - turnPwr, 3);
 
     // float tempbsn = getBSN();
 
     // scale the motor power, so it doesnt exceed 1, which would be bad
     // if ((r + abs(turnPwr)) > tempbsn) {
-    //     setMotorPwr(getMotorPwr(0) / (r + abs(turnPwr)), 0);
-    //     setMotorPwr(getMotorPwr(1) / (r + abs(turnPwr)), 1);
-    //     setMotorPwr(getMotorPwr(2) / (r + abs(turnPwr)), 2);
-    //     setMotorPwr(getMotorPwr(3) / (r + abs(turnPwr)), 3);
+    //     setReqMotorPwr(getReqMotorPwr(0) / (r + abs(turnPwr)), 0);
+    //     setReqMotorPwr(getReqMotorPwr(1) / (r + abs(turnPwr)), 1);
+    //     setReqMotorPwr(getReqMotorPwr(2) / (r + abs(turnPwr)), 2);
+    //     setReqMotorPwr(getReqMotorPwr(3) / (r + abs(turnPwr)), 3);
     // }
 
 }
@@ -119,15 +119,15 @@ void DriveMecanum::update() {
     generateMotorValues();
 
     // ramp may need removed, including for testing purposes
-    // setMotorPwr(ramp(getMotorPwr(0), 0), 0);
-    // setMotorPwr(ramp(getMotorPwr(1), 1), 1);
-    // setMotorPwr(ramp(getMotorPwr(2), 2), 2);
-    // setMotorPwr(ramp(getMotorPwr(3), 3), 3);
+    // setReqMotorPwr(ramp(getReqMotorPwr(0), 0), 0);
+    // setReqMotorPwr(ramp(getReqMotorPwr(1), 1), 1);
+    // setReqMotorPwr(ramp(getReqMotorPwr(2), 2), 2);
+    // setReqMotorPwr(ramp(getReqMotorPwr(3), 3), 3);
 
-    this->LF.write(mmotorpwr[0]); // getMotorPwr(0)
-    this->RF.write(mmotorpwr[1]); // getMotorPwr(1)
-    this->LR.write(mmotorpwr[2]); // getMotorPwr(2)
-    this->RR.write(mmotorpwr[3]); // getMotorPwr(3)
+    this->LF.write(mmotorpwr[0]); // getReqMotorPwr(0)
+    this->RF.write(mmotorpwr[1]); // getReqMotorPwr(1)
+    this->LR.write(mmotorpwr[2]); // getReqMotorPwr(2)
+    this->RR.write(mmotorpwr[3]); // getReqMotorPwr(3)
 }
 
 void DriveMecanum::drift() {
@@ -151,7 +151,7 @@ void DriveMecanum::printDebugInfo() {
     for (int i = 0; i < NUM_MOTORS; i++) {
         Serial.print(i);
         Serial.print(F("  "));
-        Serial.print(getMotorPwr(i));
+        Serial.print(getReqMotorPwr(i));
         Serial.print(F("  "));
     }
     Serial.print(F("\n"));

--- a/src/Drive/DriveMecanum.h
+++ b/src/Drive/DriveMecanum.h
@@ -35,7 +35,7 @@ public:
     DriveMecanum();
     void setServos(uint8_t lfpin, uint8_t rfpin, uint8_t lrpin, uint8_t rrpin);
     void setStickPwr(int8_t leftX, int8_t leftY, int8_t rightX);
-    // float getMotorPwr(uint8_t mtr);
+    // float getReqMotorPwr(uint8_t mtr);
     void emergencyStop();
     void update();
     void drift();

--- a/src/Drive/DriveQuick.cpp
+++ b/src/Drive/DriveQuick.cpp
@@ -25,8 +25,8 @@ Features:
  */
 // void DriveQuick::generateMotionValues() {
 //     // generate the motion vector in polar form
-//     this->r = hypot(getFwdRev(), getTurn());
-//     this->falconTurnPwr = atan2(getFwdRev(), getTurn());
+//     this->r = hypot(getForwardPower(), getTurnPower());
+//     this->falconTurnPwr = atan2(getForwardPower(), getTurnPower());
 
 //     // ensure the magnitude of the speed does not go over 1 and multiply it by the bsn value
 //     this->r = constrain(this->r, 0, 1) * getBSN(); 
@@ -53,8 +53,8 @@ void DriveQuick::update() {
     // calculate the ramped power
     // falcon_motor_pwr[0] = ramp(falcon_motor_pwr[0], 0);
     // falcon_motor_pwr[1] = ramp(falcon_motor_pwr[1], 1);
-    falcon_motor_pwr[0] = ramp(getMotorPwr(0), 0, RB_ACCELERATION_RATE);
-    falcon_motor_pwr[1] = ramp(getMotorPwr(1), 1, RB_ACCELERATION_RATE);
+    falcon_motor_pwr[0] = ramp(getReqMotorPwr(0), 0, RB_ACCELERATION_RATE);
+    falcon_motor_pwr[1] = ramp(getReqMotorPwr(1), 1, RB_ACCELERATION_RATE);
 
     // set the last ramp power, used in ramp
     setLastRampPwr(falcon_motor_pwr[0], 0);

--- a/src/Pairing/pairing.cpp
+++ b/src/Pairing/pairing.cpp
@@ -33,7 +33,7 @@
 #include <ps5Controller.h>
 #include <Preferences.h> // to store address of controller on flash
 #include "pairing.h" // also includes PolarRobotics.h
-#include <Robot/builtinLED.h> // pairing routine flashes LED to signify stages of pairing
+#include <Robot/builtInLED.h> // pairing routine flashes LED to signify stages of pairing
 
 #if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
 #error Bluetooth is not enabled! Please run `make menuconfig` to and enable it

--- a/src/Robot/MotorControl.cpp
+++ b/src/Robot/MotorControl.cpp
@@ -156,11 +156,11 @@ void MotorControl::writelow() {
 //     digitalWrite(motorPins[pin], LOW);
 //     delayMicroseconds(2000 - Convert2PWM(pwr) - 40); //-170
 //     // digitalWrite(motorPins[0], HIGH);
-//     // delayMicroseconds(Convert2PWMVal(motorPower[0]) - 40);
+//     // delayMicroseconds(Convert2PWMVal(requestedMotorPower[0]) - 40);
 //     // digitalWrite(motorPins[0], LOW);
-//     // // delayMicroseconds(2000 - Convert2PWMVal(motorPower[0]) - 40); //-170
+//     // // delayMicroseconds(2000 - Convert2PWMVal(requestedMotorPower[0]) - 40); //-170
 //     // digitalWrite(motorPins[1], HIGH);
-//     // delayMicroseconds(Convert2PWMVal(motorPower[1]) - 40);
+//     // delayMicroseconds(Convert2PWMVal(requestedMotorPower[1]) - 40);
 //     // digitalWrite(motorPins[1], LOW);
-//     // delayMicroseconds(2000 - Convert2PWMVal(motorPower[1]) - 40); //-170
+//     // delayMicroseconds(2000 - Convert2PWMVal(requestedMotorPower[1]) - 40); //-170
 // }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,16 +178,12 @@ void loop() {
         #endif
         
         // Update the motors based on the inputs from the controller
-        if(ps5.L2()) { 
-            // ps5.setLed(255, 255, 0);   // set LED yellow
-            DriveMotors.drift();
-        } else {
-            DriveMotors.update();
+
+        DriveMotors.update();
             
-            DriveMotors.printDebugInfo(); // comment this line out to reduce compile time and memory usage
-        }
-        // Serial.printf("Left: x: %d, y: %d, Right: x: %d, y: %d\n", 
-        // PS5.LStickX(), PS5.LStickY(), PS5.RStickX(), PS5.RStickY());
+        DriveMotors.printDebugInfo(); // comment this line out to reduce compile time and memory usage
+        
+        
 
     // Special Bot Actions
     #if BOT_TYPE == 0    // Lineman


### PR DESCRIPTION
Pairing includes were incorrect, platformio.ini was still pointing to Pairing/... instead of Robot/... - Also, include builtInLED.h was misspelled in pairing.cpp. Should build fine now. Drive variables also renamed to be more descriptive.