### PR TITLE
Fixed a lot of errors in platformio.ini, along with various pairing-r…

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -31,12 +31,18 @@ build_src_filter =
 	+<Robot/MotorControl.h>
   +<Robot/MotorControl.cpp>
   +<Robot/Lights.h>
-  +<Pairing/pairing.h>
-  +<Pairing/pairing.cpp>
-  +<Utilities/ReadConfig.h>
-  +<Utilities/ReadConfig.cpp>	
   +<Robot/builtInLED.h>
   +<Robot/builtInLED.cpp>	
+  +<Pairing/pairing.h>
+  +<Pairing/pairing.cpp>
+  +<Utilities/BotTypes.h>
+  +<Utilities/BotTypes.cpp>
+  +<Utilities/MotorTypes.h>
+  +<Utilities/MotorTypes.cpp>
+  +<Utilities/ConfigManager.h>
+  +<Utilities/ConfigManager.cpp>
+  +<Utilities/Pair.h>
+
 ; -<depairingStation.cpp>
 ; -<Drive/DriveQuick.cpp>
 ; -<Drive/DriveQuick.h>
@@ -116,12 +122,12 @@ build_flags =
 [env:depairing]
 build_src_filter = 
     -<*>
-    +<depairingStation.cpp>
+    +<PolarRobotics.h>
+    +<Pairing/depairingStation.cpp>
     +<Pairing/pairing.h>
     +<Pairing/pairing.cpp>
-    +<PolarRobotics.h>
-    +<Pairing/builtInLED.h>
-    +<Pairing/builtInLED.cpp>
+    +<Robot/builtInLED.h>
+    +<Robot/builtInLED.cpp>
 
 [env:address]
 build_src_filter = 
@@ -132,6 +138,7 @@ build_src_filter =
 build_flags = -D CFG_WRITABLE=1
 build_src_filter =
     -<*>
+    +<PolarRobotics.h>
     +<Utilities/WriteBotInfo.cpp>
     +<Utilities/BotTypes.h>
     +<Utilities/BotTypes.cpp>
@@ -140,16 +147,17 @@ build_src_filter =
     +<Utilities/Pair.h>
     +<Utilities/ConfigManager.h>
     +<Utilities/ConfigManager.cpp>
-    +<PolarRobotics.h>
 
 [env:read_bot_info]
 build_src_filter =
     -<*>
+    +<PolarRobotics.h>
     +<Utilities/ReadBotInfo.cpp>
     +<Utilities/BotTypes.h>
+    +<Utilities/BotTypes.cpp>
     +<Utilities/MotorTypes.h>
+    +<Utilities/MotorTypes.cpp>
     +<Utilities/Pair.h>
     +<Utilities/ConfigManager.h>
     +<Utilities/ConfigManager.cpp>
-    +<PolarRobotics.h>
 

--- a/src/Pairing/depairingStation.cpp
+++ b/src/Pairing/depairingStation.cpp
@@ -14,8 +14,12 @@
 // Custom Polar Robotics Libraries:
 #include "PolarRobotics.h"
 #include "Pairing/pairing.h"
-#include <Robot/builtinLED.h>
+#include <Robot/builtInLED.h>
 
+// Fix linker errors with build environments not including main.cpp
+#ifndef LIGHTS_H_
+void extUpdateLEDs() {}
+#endif
 
 // Lights robotLED;
 

--- a/src/Pairing/pairing.cpp
+++ b/src/Pairing/pairing.cpp
@@ -32,7 +32,7 @@
 #include <BluetoothSerial.h>
 #include <ps5Controller.h>
 #include <Preferences.h> // to store address of controller on flash
-#include "pairing.h" // also includes PolarRobotics.h
+#include "Pairing/pairing.h" // also includes PolarRobotics.h
 #include <Robot/builtInLED.h> // pairing routine flashes LED to signify stages of pairing
 
 #if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)

--- a/src/Pairing/pairing.h
+++ b/src/Pairing/pairing.h
@@ -2,5 +2,9 @@
 #define PAIRING_H_
 #include "PolarRobotics.h"
 #define DEFAULT_BT_DISCOVER_TIME 15000
+bool addressIsController(const char * addrCharPtr);
+bool startDiscovery();
+void storeAddress(const char *addr, bool clear);
+void getAddress(const char *&addr);
 void activatePairing(bool doRePair = true, int discoverTime = DEFAULT_BT_DISCOVER_TIME);
 #endif

--- a/src/Robot/Lights.h
+++ b/src/Robot/Lights.h
@@ -1,7 +1,7 @@
 // void updateLEDS(BOT_STATE status); //private
 // void setRobotState(BOT_STATE state);
-#pragma once
-#include <Arduino.h>
+#ifndef LIGHTS_H_
+#define LIGHTS_H_
 #include <FastLED.h>
 #include <PolarRobotics.h>
 
@@ -130,3 +130,5 @@ int Lights::returnStatus() {
     status = currState;
     return status;
 }
+
+#endif // Lights.h

--- a/src/Robot/builtInLED.cpp
+++ b/src/Robot/builtInLED.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#include "builtinLED.h"
+#include "Robot/builtInLED.h"
 
 /**
  * @brief Implementation of builtInLED.h

--- a/src/Robot/builtInLED.h
+++ b/src/Robot/builtInLED.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef __BUILT_IN_LED_H__
+#define __BUILT_IN_LED_H__
 
 /**
  * @brief Header for Global ESP Built-In LED Handling
@@ -16,3 +17,5 @@
 bool builtInLedOn();
 void toggleBuiltInLED();
 void setBuiltInLED(bool on = true);
+
+#endif // !__BUILT_IN_LED_H__


### PR DESCRIPTION
`depairingStation.cpp`: was not linking due to `extUpdateLEDs()` being added into `pairing.cpp`, added a 'fake definition' bound by an include guard to this file to solve this issue.

`pairing.cpp`: Clarified `pairing.h` include path. Using double quotes (relative pathing?) so it may be unnecessary, but better safe than sorry.

`pairing.h`: added declarations for helper methods of `pairing.cpp`, apparently Rhys's linker was throwing a fit since they didn't exist.

`builtInLED.cpp`: fixed include path; same as `pairing.cpp`

`builtInLED.h` and `Lights.h`: added include guards; removed `#pragma once`

Future work: should refactor `Lights.h` to Singleton SDP