### PR TITLE
Fixed issues with `dev/oop-fixed`

### DIFF
--- a/src/Drive/Drive.cpp
+++ b/src/Drive/Drive.cpp
@@ -146,20 +146,12 @@ void Drive::setBSN(Speed bsn) {
             break;
         }
         case NORMAL: {
-            if (motorType == falcon) {
-              Serial.println(F("FALCON MOTORS DETECTED"));
-            }
-
             switch (motorType) {
                 case MotorType::big: { BSNscalar = BIG_NORMAL_PCT; break; }
                 case MotorType::small: { BSNscalar = SMALL_NORMAL_PCT; break; }
                 case MotorType::mecanum: { BSNscalar = MECANUM_NORMAL_PCT; break; }
                 case MotorType::falcon: { BSNscalar = FALCON_NORMAL_PCT; break; }
             }
-            Serial.print(F("BSN SETTING TO NORMAL, "));
-            Serial.print(FALCON_NORMAL_PCT);
-            Serial.print(F(" ?= "));
-            Serial.println(BSNscalar);
             break;
         }
         case SLOW: {
@@ -230,24 +222,6 @@ void Drive::generateMotionValues() {
             }
         }
     }
-
-    Serial.print(F("fwd, turn sticks IN GMV: "));
-    Serial.print(stickForwardRev);
-    Serial.print(F(", "));
-    Serial.print(stickTurn);
-    Serial.print(F(" | "));
-    Serial.print(F("BSN IN GMV: "));
-    Serial.print(BSNscalar);
-    Serial.print(F(" | "));
-    Serial.print(F("reqMtrPwrs IN GMV: "));
-    Serial.print(requestedMotorPower[0]);
-    Serial.print(F(", "));
-    Serial.print(requestedMotorPower[1]);
-    Serial.print(F(" | "));
-    Serial.print(F("turnMtrVals IN GMV: "));
-    Serial.print(turnMotorValues[0]);
-    Serial.print(F(", "));
-    Serial.println(turnMotorValues[1]);
 }
 
 

--- a/src/Drive/Drive.cpp
+++ b/src/Drive/Drive.cpp
@@ -214,6 +214,11 @@ void Drive::generateMotionValues() {
             }
         }
     }
+
+    Serial.print(F("reqMtrPwrs IN GMV: "));
+    Serial.print(requestedMotorPower[0]);
+    Serial.print(F(", "));
+    Serial.println(requestedMotorPower[1]);
 }
 
 

--- a/src/Drive/Drive.cpp
+++ b/src/Drive/Drive.cpp
@@ -70,6 +70,14 @@ Drive::Drive(BotType botType, MotorType motorType) {
     this->BIG_NORMAL_PCT = 0.6; 
     this->BIG_SLOW_PCT = 0.3;
   }
+
+  // initialize arrays
+  for (int i = 0; i < NUM_MOTORS; i++) {
+    requestedMotorPower[i] = 0.0f;
+    currentRampPower[i] = 0.0f;
+    lastRampPower[i] = 0.0f;
+    turnMotorValues[i] = 0.0f;
+  }
 }
 
 void Drive::setServos(uint8_t lpin, uint8_t rpin) {

--- a/src/Drive/Drive.cpp
+++ b/src/Drive/Drive.cpp
@@ -138,12 +138,20 @@ void Drive::setBSN(Speed bsn) {
             break;
         }
         case NORMAL: {
+            if (motorType == falcon) {
+              Serial.println(F("FALCON MOTORS DETECTED"));
+            }
+
             switch (motorType) {
                 case MotorType::big: { BSNscalar = BIG_NORMAL_PCT; break; }
                 case MotorType::small: { BSNscalar = SMALL_NORMAL_PCT; break; }
                 case MotorType::mecanum: { BSNscalar = MECANUM_NORMAL_PCT; break; }
                 case MotorType::falcon: { BSNscalar = FALCON_NORMAL_PCT; break; }
             }
+            Serial.print(F("BSN SETTING TO NORMAL, "));
+            Serial.print(FALCON_NORMAL_PCT);
+            Serial.print(F(" ?= "));
+            Serial.println(BSNscalar);
             break;
         }
         case SLOW: {
@@ -215,10 +223,23 @@ void Drive::generateMotionValues() {
         }
     }
 
+    Serial.print(F("fwd, turn sticks IN GMV: "));
+    Serial.print(stickForwardRev);
+    Serial.print(F(", "));
+    Serial.print(stickTurn);
+    Serial.print(F(" | "));
+    Serial.print(F("BSN IN GMV: "));
+    Serial.print(BSNscalar);
+    Serial.print(F(" | "));
     Serial.print(F("reqMtrPwrs IN GMV: "));
     Serial.print(requestedMotorPower[0]);
     Serial.print(F(", "));
-    Serial.println(requestedMotorPower[1]);
+    Serial.print(requestedMotorPower[1]);
+    Serial.print(F(" | "));
+    Serial.print(F("turnMtrVals IN GMV: "));
+    Serial.print(turnMotorValues[0]);
+    Serial.print(F(", "));
+    Serial.println(turnMotorValues[1]);
 }
 
 

--- a/src/Drive/Drive.h
+++ b/src/Drive/Drive.h
@@ -79,8 +79,8 @@
 
 // BSN for the falcon motors used on the runningback
 #define FALCON_BOOST_PCT  1.0
-#define FALCON_NORMAL_PCT 0.4
-#define FALCON_SLOW_PCT   0.3
+#define FALCON_NORMAL_PCT 0.5
+#define FALCON_SLOW_PCT   0.1
 
 #define BRAKE_BUTTON_PCT 0
 
@@ -125,8 +125,8 @@ class Drive {
     void emergencyStop();
     float ramp(float requestedPower, uint8_t mtr, float accelRate = ACCELERATION_RATE);
     void generateMotionValues();
-    void update();
-    void printDebugInfo();
+    virtual void update();
+    virtual void printDebugInfo();
 
     //* The following variables are initialized in the constructor
     // the max allowable turning when the bot is traveling at lowest speed

--- a/src/Drive/DriveQuick.cpp
+++ b/src/Drive/DriveQuick.cpp
@@ -50,12 +50,6 @@ void DriveQuick::update() {
     // Generate turning motion
     generateMotionValues();
 
-    Serial.print(F("reqMtrPwrs: "));
-    Serial.print(getReqMotorPwr(0));
-    Serial.print(F(", "));
-    Serial.print(getReqMotorPwr(1));
-    Serial.print(F(" | "));
-
     // calculate the ramped power
     // falcon_motor_pwr[0] = ramp(falcon_motor_pwr[0], 0);
     // falcon_motor_pwr[1] = ramp(falcon_motor_pwr[1], 1);
@@ -74,12 +68,6 @@ void DriveQuick::update() {
     // note: adding a negative, because we cant change the motor direction in hardware
     M1.write(falcon_motor_pwr[0]);
     M2.write(-falcon_motor_pwr[1]);
-
-    Serial.print(F("falcMtrPwrs: "));
-    Serial.print(falcon_motor_pwr[0]);
-    Serial.print(F(", "));
-    Serial.print(falcon_motor_pwr[1]);
-    Serial.print(F("\n"));
 }
 
 void DriveQuick::printDebugInfo() {

--- a/src/Drive/DriveQuick.cpp
+++ b/src/Drive/DriveQuick.cpp
@@ -50,6 +50,12 @@ void DriveQuick::update() {
     // Generate turning motion
     generateMotionValues();
 
+    Serial.print(F("reqMtrPwrs: "));
+    Serial.print(getReqMotorPwr(0));
+    Serial.print(F(", "));
+    Serial.print(getReqMotorPwr(1));
+    Serial.print(F(" | "));
+
     // calculate the ramped power
     // falcon_motor_pwr[0] = ramp(falcon_motor_pwr[0], 0);
     // falcon_motor_pwr[1] = ramp(falcon_motor_pwr[1], 1);
@@ -67,6 +73,28 @@ void DriveQuick::update() {
     // write calculated powers to the motors 
     // note: adding a negative, because we cant change the motor direction in hardware
     M1.write(falcon_motor_pwr[0]);
-    M2.write(-falcon_motor_pwr[1]); 
+    M2.write(-falcon_motor_pwr[1]);
+
+    Serial.print(F("falcMtrPwrs: "));
+    Serial.print(falcon_motor_pwr[0]);
+    Serial.print(F(", "));
+    Serial.print(falcon_motor_pwr[1]);
+    Serial.print(F("\n"));
 }
 
+void DriveQuick::printDebugInfo() {
+    Serial.print(F("DQ | "));
+    Serial.print(F("L_Hat_Y: "));
+    Serial.print(stickForwardRev);
+    Serial.print(F("  R_HAT_X: "));
+    Serial.print(stickTurn);
+
+    // Serial.print(F("  |  Turn: "));
+    // Serial.print(lastTurnPwr);
+
+    Serial.print(F("  L_MotPwr: "));
+    Serial.print(falcon_motor_pwr[0]);
+    Serial.print(F("  R_MotPwr: "));
+    Serial.print(falcon_motor_pwr[1]);
+    Serial.print(F("\n"));
+}

--- a/src/Drive/DriveQuick.h
+++ b/src/Drive/DriveQuick.h
@@ -1,8 +1,8 @@
 #ifndef DRIVE_QUICK_H
 #define DRIVE_QUICK_H
 // the minimum power that can be written to the motor, prevents stalling
-#define MOTOR_ZERO_OFFST 0
-#define RB_ACCELERATION_RATE 0.03f
+#define MOTOR_ZERO_OFFST 0.05
+#define RB_ACCELERATION_RATE 0.02f //default: 0.0375f, Runningback old: 0.03f, 0.015f
 #include <Drive/Drive.h>
 
 class DriveQuick : public Drive {
@@ -11,7 +11,8 @@ class DriveQuick : public Drive {
     float r, falconTurnPwr, max;
   public:
     // void generateMotionValues();
-    void update();
+    void update() override;
+    void printDebugInfo() override;
 };
 
 #endif // DRIVE_QUICK_H

--- a/src/Drive/DriveQuick.h
+++ b/src/Drive/DriveQuick.h
@@ -10,6 +10,8 @@ class DriveQuick : public Drive {
     float falcon_motor_pwr[NUM_MOTORS];
     float r, falconTurnPwr, max;
   public:
+    //! Must call base class constructor with appropriate arguments
+    DriveQuick() : Drive(BotType::runningback, MotorType::falcon) {}
     // void generateMotionValues();
     void update() override;
     void printDebugInfo() override;

--- a/src/Robot/Quarterback.h
+++ b/src/Robot/Quarterback.h
@@ -60,10 +60,10 @@ class Quarterback : public Robot {
     bool raise, lower;
     bool setupMotors;
     uint8_t currentElevation, targetElevation;
-    unsigned long lastElevationTime;
-    unsigned long lastFlywheelToggleTime;
-    unsigned long lastFlywheelRampTime;
-    float currentFlywheelPower;
+    unsigned long lastElevationTime = 0;
+    unsigned long lastFlywheelToggleTime = 0;
+    unsigned long lastFlywheelRampTime = 0;
+    float currentFlywheelPower = 0;
     float flywheelSpeedFactor = 0;
     unsigned long lastDBElev = 0, lastDBFW = 0, lastDBFWChange = 0, lastDBConv = 0; // DB is for debounce
     const float speedFac[NUM_SPEED_INCREMENTS] = { 0.0, 0.3, 0.5, 0.8 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,6 +154,7 @@ void loop() {
     if (ps5.Touchpad()){
       drive->emergencyStop();
       drive->setBSN(Drive::BRAKE);
+      Serial.println(F("BRAKING!!!"));
     } else if (ps5.R1()) {
       drive->setBSN(Drive::BOOST);
       // ps5.setLed(0, 255, 0);   // set LED red

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,7 +154,6 @@ void loop() {
     if (ps5.Touchpad()){
       drive->emergencyStop();
       drive->setBSN(Drive::BRAKE);
-      Serial.println(F("BRAKING!!!"));
     } else if (ps5.R1()) {
       drive->setBSN(Drive::BOOST);
       // ps5.setLed(0, 255, 0);   // set LED red
@@ -183,7 +182,7 @@ void loop() {
     //* Update the motors based on the inputs from the controller
     //* Can change functionality depending on subclass, like robot.action()
     drive->update();
-    drive->printDebugInfo(); // comment this line out to reduce compile time and memory usage
+    // drive->printDebugInfo(); // comment this line out to reduce compile time and memory usage
 
     //! Performs all special robot actions depending on the instantiated Robot subclass
     robot->action();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,7 +168,7 @@ void loop() {
       lights.togglePosition();
     }
 
-    if (robotType != lineman) {
+    if (robotType != lineman && robotType != runningback) {
       if (lights.returnStatus() == lights.OFFENSE && digitalRead(TACKLE_PIN) == LOW) {
         lights.setLEDStatus(Lights::TACKLED);
         lights.tackleTime = millis();
@@ -182,7 +182,7 @@ void loop() {
     //* Update the motors based on the inputs from the controller
     //* Can change functionality depending on subclass, like robot.action()
     drive->update();
-    // drive->printDebugInfo(); // comment this line out to reduce compile time and memory usage
+    drive->printDebugInfo(); // comment this line out to reduce compile time and memory usage
 
     //! Performs all special robot actions depending on the instantiated Robot subclass
     robot->action();


### PR DESCRIPTION
- Strange startup behaviors with QB (and later RB) were caused by lack of initialization for array/integral-type values
- Adapted the important changes from `dev/runningback-ramp-fix` into this branch
- Fixed constructor for `DriveQuick`: the motor type was not passed to the base class constructor, so `BSNscalar` was locked to zero since no `case` matched `motorType` (which was presumably `null`)


