### PR TITLE
flipped calibration/boosting buttons for Falcons

### DIFF
--- a/src/Drive/Drive.h
+++ b/src/Drive/Drive.h
@@ -45,20 +45,20 @@
 // #endif
 
 // BSN for Short/Small Motors
-#define SMALL_BOOST_PCT 0.85
-#define SMALL_NORMAL_PCT 0.7
-#define SMALL_SLOW_PCT 0.4
+#define SMALL_BOOST_PCT  0.85f
+#define SMALL_NORMAL_PCT 0.7f
+#define SMALL_SLOW_PCT   0.4f
 
 // BSN for the 12v motors used on the new center
-#define MECANUM_BOOST_PCT  0.8
-#define MECANUM_NORMAL_PCT 0.6
-#define MECANUM_SLOW_PCT   0.3
+#define MECANUM_BOOST_PCT  0.8f
+#define MECANUM_NORMAL_PCT 0.6f
+#define MECANUM_SLOW_PCT   0.3f
 
 // BSN for the falcon motors used on the runningback
-#define FALCON_BOOST_PCT  1.0
-#define FALCON_NORMAL_TREVOR_PCT 0.6 // used to make trevor(nt) happy
-#define FALCON_NORMAL_PCT 0.4 // 0.5
-#define FALCON_SLOW_PCT   0.15
+#define FALCON_CALIBRATION_FACTOR 1.0f
+#define FALCON_BOOST_PCT          0.6f
+#define FALCON_NORMAL_PCT         0.4f // 0.5
+#define FALCON_SLOW_PCT           0.15f
 
 #define BRAKE_BUTTON_PCT 0
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,8 +166,9 @@ void loop() {
       // ps5.setLed(0, 255, 0);   // set LED red
     } else if (ps5.L1()) {
       drive->setBSN(Drive::SLOW);
-    } else if (ps5.R2() && robotType == runningback) {
-      drive->setBSNValue(FALCON_NORMAL_TREVOR_PCT);
+    } else if (ps5.R2() && motorType == falcon) {
+      // used to calibrate the max pwm signal for the falcon 500 motors
+      drive->setBSNValue(FALCON_CALIBRATION_FACTOR);
     } else {
       drive->setBSN(Drive::NORMAL);
     }


### PR DESCRIPTION
Flipped the triggers so the boost (60%) is the normal R1 trigger and the calibration value (100%) is moved to the R2 trigger and cleaned up the variable names