### PR TITLE
fix tackle sensor

### DIFF
--- a/src/PolarRobotics.h
+++ b/src/PolarRobotics.h
@@ -42,7 +42,7 @@
 // pin for ws2812 LEDs to indicate positions 
 #define LED_PIN 4   
 // receiver, tackled, etc...
-#define TACKLE_PIN 12
+#define TACKLE_PIN 13
 
 enum BOT_STATE {
   PAIRING,

--- a/src/Robot/Lights.h
+++ b/src/Robot/Lights.h
@@ -41,10 +41,8 @@ public:
   void pairState(bool state);
 
   // LED Variables
-  bool tackled = false;
   unsigned long tackleTime = 0;
   const int switchTime = 1000; //! KEEP THIS HERE!!!
-  int ledStatus = 0;
 };
 
 #endif // LIGHTS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,16 +178,15 @@ void loop() {
       lights.togglePosition();
     }
 
-    if (robotType != lineman && lights.returnStatus() == lights.OFFENSE) { // && robotType != runningback
+    if (robotType != lineman) { // && lights.returnStatus() == lights.OFFENSE || lights.returnStatus() == lights.TACKLED
       if (lights.returnStatus() == lights.OFFENSE && digitalRead(TACKLE_PIN) == LOW) {
         lights.setLEDStatus(Lights::TACKLED);
         lights.tackleTime = millis();
-        lights.tackled = true;
       } 
       // debounce the tackle sensor input
-      else if ((millis() - lights.tackleTime) >= lights.switchTime && lights.tackled == true) {
+      else if ((millis() - lights.tackleTime) >= lights.switchTime && 
+          lights.returnStatus() == lights.TACKLED && digitalRead(TACKLE_PIN) == HIGH) { 
         lights.setLEDStatus(Lights::OFFENSE);
-        lights.tackled = false;
       }
     }
 


### PR DESCRIPTION
Changed the tackle pin to 13, from 12. At some point the tackle sensor pin was switched. The tackle sensor can not be on pin 12 as this pin needs to be LOW on boot, with the tackle sensor being active LOW, this pin will not work
Also fixed some of the logic around leaving the tackled state, lights still red after being tackled, also fixed the issue where the lights would flicker while in the tackled state