### PR TITLE
New Light Rules

### DIFF
--- a/src/Robot/Lights.cpp
+++ b/src/Robot/Lights.cpp
@@ -4,7 +4,7 @@
 
 Lights::Lights() {
   currState = PAIRING;
-  homeState = AWAY;
+  homeState = HOME;
 }
 
 void Lights::setupLEDS() {

--- a/src/Robot/Lights.cpp
+++ b/src/Robot/Lights.cpp
@@ -4,7 +4,7 @@
 
 Lights::Lights() {
   currState = PAIRING;
-  this->isOffense = false;
+  homeState = AWAY;
 }
 
 void Lights::setupLEDS() {
@@ -42,14 +42,11 @@ void Lights::updateLEDS() {
       break;
     }
     case OFFENSE: {
-      for(int i = 0; i < NUM_LEDS; i ++){
-        if (i % 2 == 0) { leds[i] = CRGB::Blue; }
-        else { leds[i] = CRGB::Green; }
-      }
+      leds = CRGB::Green;
       break;
     }
     case DEFENSE: {
-      leds = CRGB::Green;
+      leds = CRGB::White;
       break;
     }
     case TACKLED: {
@@ -76,13 +73,20 @@ void Lights::togglePosition() {
   // debounce makes sure you cant hold down the button, 
   // I think the ps5 library already does this, but we probably should check
   if (millis() - lastToggleTime >= TIME_BETWEEN_TOGGLES) {
-    if (this->isOffense) {
-      setLEDStatus(OFFENSE);
+    switch (homeState) {
+      case HOME:
+        setLEDStatus(OFFENSE);
+        homeState = AWAY;
+        break;
+      case AWAY:
+        setLEDStatus(DEFENSE);
+        homeState = LINEMAN;
+        break;
+      case LINEMAN:
+        setLEDStatus(OFF);
+        homeState = HOME;
+        break;
     }
-    else {
-      setLEDStatus(DEFENSE);
-    }
-    this->isOffense = !this->isOffense;
     lastToggleTime = millis();
   }
 }

--- a/src/Robot/Lights.h
+++ b/src/Robot/Lights.h
@@ -14,7 +14,7 @@ private:
   uint8_t currState;
   CRGBArray<NUM_LEDS> leds;
   uint8_t iteration;
-  bool isOffense;
+  uint8_t homeState;
   Lights();
 public:
   // MUHAMMED ENUM PRAISE BE UPON HIM
@@ -27,6 +27,11 @@ public:
     TACKLED,     // turn red when tackled
     DISCO,       // go crazy
     OFF
+  };
+  enum HomeState {
+    HOME,
+    AWAY,
+    LINEMAN
   };
   static Lights& getInstance() {
     static Lights instance;


### PR DESCRIPTION
Began altering the light code to comply with new rules. Rule changes include lighting robots by home vs. away instead of offense vs. defense and linemen will no longer be lit. Ask Alex for further details.