### PR TITLE
Added stick normalizing and eeprom for v1 lines

### DIFF
--- a/src/Drive/Drive.cpp
+++ b/src/Drive/Drive.cpp
@@ -135,16 +135,25 @@ void Drive::setStickPwr(int8_t leftY, int8_t rightX) {
     // stickForwardRev = (0 - (leftY / 127.5 - 1)); 
     // stickTurn = (rightX / 127.5 - 1); // +: right turn, -: left turn. subtracting 1 bumps into correct range
     stickForwardRev = (leftY / 127.5f);
-    stickTurn = (rightX / 127.5f);  
+    stickTurn = (rightX / 127.5f);
 
     // stick deadzones
     // set to zero (no input) if within the set deadzone
+    // subtacting STICK_DEADZONE and deviding by 1-STICK_DEADZONE normalize the inputs to use the full 0-1 range
     if (fabs(stickForwardRev) < STICK_DEADZONE)
       stickForwardRev = 0;
+    else if (stickForwardRev > 0)
+      stickForwardRev = (stickForwardRev - STICK_DEADZONE) / (1 - STICK_DEADZONE);
+    else if (stickForwardRev < 0)
+      stickForwardRev = (stickForwardRev + STICK_DEADZONE) / (1 - STICK_DEADZONE);
     
     if (fabs(stickTurn) < STICK_DEADZONE)
       stickTurn = 0;
-    
+    else if (stickTurn > 0)
+      stickTurn = (stickTurn - STICK_DEADZONE) / (1 - STICK_DEADZONE);
+    else if (stickTurn < 0)
+      stickTurn = (stickTurn + STICK_DEADZONE) / (1 - STICK_DEADZONE);
+
 }
 
 float Drive::getForwardPower() {
@@ -429,7 +438,7 @@ void Drive::printCsvInfo() {
 void Drive::update() {
     // Generate turning motion
     generateMotionValues();
-    //printDebugInfo();
+    printDebugInfo();
 
     // get the ramp value
     requestedMotorPower[0] = M1.ramp(requestedMotorPower[0], ACCELERATION_RATE);
@@ -441,8 +450,8 @@ void Drive::update() {
     
     // M1->write(requestedMotorPower[0]);
     // M2->write(requestedMotorPower[1]);
-
-    M1.write(requestedMotorPower[0]);
-    M2.write(requestedMotorPower[1]);
+    float motordiff = 0.0;
+    M1.write(requestedMotorPower[0] + motordiff);
+    M2.write(requestedMotorPower[1] - motordiff);
 }
 

--- a/src/Drive/Drive.cpp
+++ b/src/Drive/Drive.cpp
@@ -438,8 +438,7 @@ void Drive::printCsvInfo() {
 void Drive::update() {
     // Generate turning motion
     generateMotionValues();
-    printDebugInfo();
-
+    
     // get the ramp value
     requestedMotorPower[0] = M1.ramp(requestedMotorPower[0], ACCELERATION_RATE);
     requestedMotorPower[1] = M2.ramp(requestedMotorPower[1], ACCELERATION_RATE);

--- a/src/Drive/Drive.h
+++ b/src/Drive/Drive.h
@@ -33,6 +33,8 @@
 #define THRESHOLD 0.00001
 
 
+
+
 // MOTOR MAX SPEED DEFINES;
 // this is 1.0, the maximum power possible to the motors.
 // #if BOT_TYPE == 4

--- a/src/PolarRobotics.h
+++ b/src/PolarRobotics.h
@@ -13,7 +13,7 @@
 #include <Utilities/MotorTypes.h>
 #include <Utilities/DriveParameters.h>
 
-#define PR_CODEBASE_VERSION "2.3.2 @ production"
+#define PR_CODEBASE_VERSION "2.3.4 @ production"
 
 // [PIN DECLARATIONS]
 // please follow: 

--- a/src/Utilities/BotTypes.h
+++ b/src/Utilities/BotTypes.h
@@ -58,7 +58,7 @@ typedef struct BotConfig {
   // BotType secondary_type;
 } bot_config_t;
 
-#define NUM_BOTS 14
+#define NUM_BOTS 17
 
 // Bot Aliases
 #define BOT_IPP         0
@@ -80,6 +80,10 @@ typedef struct BotConfig {
 #define BOT_THETA       12
 #define BOT_KICKER      12
 #define BOT_LINEMAN_V1  13
+#define BOT_420         14
+#define BOT_24          15
+#define BOT_25          16
+
 
 // PRESET BOT CONFIGURATIONS, MUST MATCH:
 // https://docs.google.com/spreadsheets/d/1DswoEAcry9L9t_4ouKL3mXFgDMey4KkjEPFXULQxMEQ/edit#gid=0
@@ -98,7 +102,10 @@ constexpr bot_config_t botConfigArray[NUM_BOTS] = {
   { 10, "phi",      center,      big_ampflow,    { 0.6f,      11.50f,  9.00f,  36.00f }},  //* 10: Φ (actually small_ampflow)
   { 11, "inf",      quarterback, small_ampflow,  { 0.5625f,   11.50f,  9.00f,  36.00f }},  //* 11: ∞
   { 12, "theta",    kicker,      small_ampflow,  { 0.34375f,  10.00f,  9.00f,  36.00f }},  //* 12: Θ
-  { 13, "l-man-v1", lineman,     small_12v,      { 1.0f,      11.00f,  9.00f,  36.00f }}   //* 13: generic lineman
+  { 13, "l-man-v1", lineman,     small_12v,      { 1.0f,      11.00f,  9.00f,  36.00f }},  //* 13: generic lineman
+  { 14, "420",      lineman,     small_12v,      { 1.0f,      11.00f,  5.50f,  18.00f }},  //* 14: 420 
+  { 15, "24",       lineman,     small_12v,      { 1.0f,      11.00f,  5.50f,  18.00f }},  //* 15: 24 
+  { 16, "25",       lineman,     small_12v,      { 1.0f,      11.00f,  5.50f,  18.00f }}   //* 16: 25
 };
 
 //! Do not decrease r_min to less than half of the wheelbase, or the math might break

--- a/src/Utilities/WriteBotInfo.cpp
+++ b/src/Utilities/WriteBotInfo.cpp
@@ -16,7 +16,7 @@ void setup() {
   //! If you want to use a predefined robot from BotTypes.h, declare the index here:
   // based on https://docs.google.com/spreadsheets/d/1DswoEAcry9L9t_4ouKL3mXFgDMey4KkjEPFXULQxMEQ/edit#gid=0
   //! Please reset to zero when you are done uploading to avoid merge conflicts.
-  uint8_t index = 0; // also handles bot name index
+  uint8_t index = 14; // also handles bot name index
 
   //* CUSTOM BOT CONFIGURATION
   //! If you want to set custom bot and motor type, assign index appropriately, then assign these:

--- a/src/Utilities/WriteBotInfo.cpp
+++ b/src/Utilities/WriteBotInfo.cpp
@@ -16,7 +16,7 @@ void setup() {
   //! If you want to use a predefined robot from BotTypes.h, declare the index here:
   // based on https://docs.google.com/spreadsheets/d/1DswoEAcry9L9t_4ouKL3mXFgDMey4KkjEPFXULQxMEQ/edit#gid=0
   //! Please reset to zero when you are done uploading to avoid merge conflicts.
-  uint8_t index = 14; // also handles bot name index
+  uint8_t index = 0; // also handles bot name index
 
   //* CUSTOM BOT CONFIGURATION
   //! If you want to set custom bot and motor type, assign index appropriately, then assign these:


### PR DESCRIPTION
Adding normalizing for the stick values will allow the full rang of 0-1 to still be used with any dead-zone value, this is important for the old bots as they only use .1 of the range and the current dead-zone is 0.075 leaving an affective 0.025 of control on the sticks. Also this pull added eeprom values for 3 of our old bots 420, 24, and 25