### PR TITLE
merge prod - Fixed compilation issues with FastLed

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ board = nodemcu-32s
 board_build.mcu = esp32
 upload_protocol = esptool
 lib_deps = 
-	fastled/FastLED@^3.5.0
+	fastled/FastLED @ ~3.6.0
   https://github.com/PolarRobotics/PR-Lib.git
 extra_scripts = pre:pio_build_script.py
 


### PR DESCRIPTION
Rhys: With the newer of FastLED, 3.7.0 it doesn't seem to like the compiler platformio uses, so I forced PIO to use an older version of FastLED, this library does not always need to be 100% up to date